### PR TITLE
Fix recipe for get placable colorize item. Add settings for consume dye when recoloring.

### DIFF
--- a/marble.lua
+++ b/marble.lua
@@ -176,12 +176,18 @@ local types = {
 -- Palette colors and corresponding dyes
 local palette = {[0] = "#0058af", "#ffdf7e", "#040404", "#fd294d", "#fa8a2d", "#067f23", "#8f54f5", "#f39ae4"}
 local dyes = {["dye:blue"] = 0, ["dye:yellow"] = 1, ["dye:black"] = 2, ["dye:red"] = 3, ["dye:orange"] = 4, ["dye:green"] = 5, ["dye:violet"] = 6, ["dye:pink"] = 7}
+local consume_dye = greek.settings_get("consuming_dye")
 
 local dye_punch = function(pos, node, puncher, pointed)
     if not minetest.is_protected(pos, puncher:get_player_name()) then
         local stack = puncher:get_wielded_item():get_name()
         if dyes[stack] then
             minetest.swap_node(pos, {name = node.name, param2 = (dyes[stack] * 32) + (node.param2 % 32)})
+            if consume_dye then
+                local item = puncher:get_wielded_item()
+                item:take_item(1)
+                puncher:set_wielded_item(item)
+            end
         end
     end
     return minetest.node_punch(pos, node, puncher, pointed)
@@ -207,10 +213,14 @@ for type, data in pairs(types) do
         })
 
         for dye, color in pairs(dyes) do
+            local use_replacements = {{dye, dye}}
+            if consume_dye then
+                use_replacements = nil
+            end
             minetest.register_craft({
                 output = minetest.itemstring_with_palette(name, color*32),
                 recipe = {name, dye},
-                replacements = {{dye, dye}},
+                replacements = use_replacements,
                 type = "shapeless",
             })
         end

--- a/marble.lua
+++ b/marble.lua
@@ -199,7 +199,7 @@ for type, data in pairs(types) do
             overlay_tiles = {tile, tile .. "^[transformFX", tile, tile .. "^[transformFY", tile .. "^[transformFX",  tile .. "^[transformR180"},
             paramtype2 = "colorfacedir",
             palette = "greek_marble_painted_palette.png",
-            color = palette[0], -- This is used for inventory color
+            --color = palette[0], -- This is used for inventory color
             use_texture_alpha = true,
             groups = greek.marble_groups,
             sounds = greek.marble_sounds,
@@ -208,7 +208,7 @@ for type, data in pairs(types) do
 
         for dye, color in pairs(dyes) do
             minetest.register_craft({
-                output = minetest.itemstring_with_color(name, palette[color]),
+                output = minetest.itemstring_with_palette(name, color*32),
                 recipe = {name, dye},
                 replacements = {{dye, dye}},
                 type = "shapeless",
@@ -219,19 +219,22 @@ for type, data in pairs(types) do
     greek.register_craftring("greek:marble_painted_" .. type .. "_%s", total)
 
     -- Fill recipe template with items
-    local items = {[0] = "greek:marble_polished", "group:dye"}
-    for _, recipe in pairs(data[2]) do
-        local filled = {}
-        for row in pairs(recipe) do
-            filled[row] = {}
-            for col in pairs(recipe[row]) do
-                filled[row][col] = items[recipe[row][col]]
+    for dye, color in pairs(dyes) do
+        local name = ("greek:marble_painted_%s_1 4"):format(type)
+        local items = {[0] = "greek:marble_polished", dye}
+        for _, recipe in pairs(data[2]) do
+            local filled = {}
+            for row in pairs(recipe) do
+                filled[row] = {}
+                for col in pairs(recipe[row]) do
+                    filled[row][col] = items[recipe[row][col]]
+                end
             end
-        end
 
-        minetest.register_craft({
-            output = ("greek:marble_painted_%s_1 4"):format(type),
-            recipe = filled,
-        })
+            minetest.register_craft({
+                output = minetest.itemstring_with_palette(name, color*32),
+                recipe = filled,
+            })
+        end
     end
 end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -5,6 +5,9 @@ greek.show_stairs_in_creative (Show stairs in creative inventory) bool false
 #    Order this list by priority (descending) for greeknodes marble aliasing.
 greek.marble (Marble item list) string building_blocks:Marble,darkage:marble,technic:marble
 
+#    Enable/disable consuming of dye when recoloring.
+greek.consuming_dye (Enable consuming of dye when recoloring.) bool false
+
 #    Comma-separated list of items that can be used as limestone for cement-making.
 greek.limestone (Limestone item list) string default:silver_sandstone,darkage:chalk
 


### PR DESCRIPTION
1. In the master branch, when I craft colorized marble node, It place node always colorized with blue color. This problem is solved by replacing itemstring_with_color with itemstring_with_palette.
2. Add configurable consuming of color when recoloring node.