### PR TITLE
Fix broken crafts with `greek:blue_wood`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ G = greek:gilded_gold
 
 `greek:door_1_a 2`:  
 ```
-W = group:greek:blue_wood
+W = greek:blue_wood
 +-+-+
 |W|W|
 +-+-+
@@ -392,7 +392,7 @@ Replacements: (group:water_bucket, bucket:bucket_empty)
 
 `greek:shutters_1 2`:  
 ```
-W = group:greek:blue_wood
+W = greek:blue_wood
 +-+-+-+
 |W| |W|
 +-+-+-+

--- a/doors.lua
+++ b/doors.lua
@@ -256,9 +256,9 @@ end
 minetest.register_craft({
     output = "greek:door_1_a 2",
     recipe = {
-        {"group:greek:blue_wood", "group:greek:blue_wood"},
-        {"group:greek:blue_wood", "group:greek:blue_wood"},
-        {"group:greek:blue_wood", "group:greek:blue_wood"},
+        {"greek:blue_wood", "greek:blue_wood"},
+        {"greek:blue_wood", "greek:blue_wood"},
+        {"greek:blue_wood", "greek:blue_wood"},
     },
 })
 
@@ -325,7 +325,7 @@ greek.register_craftring("greek:shutters_%s", shutter_count)
 minetest.register_craft({
     output = "greek:shutters_1 2",
     recipe = {
-        {"group:greek:blue_wood", "", "group:greek:blue_wood"},
-        {"group:greek:blue_wood", "", "group:greek:blue_wood"},
+        {"greek:blue_wood", "", "greek:blue_wood"},
+        {"greek:blue_wood", "", "greek:blue_wood"},
     },
 })


### PR DESCRIPTION
Fixes https://github.com/Archtec-io/bugtracker/issues/165

This fixes the recipes of `greek:door_1_a` (resulted in `doors:door_wood`) and `greek:shutters_1` (resulted in `3d_armor:boots_wood`). The downside is, that this breaks the `greek.blue_wood` setting.